### PR TITLE
upgrade gh action artifact-upload to v4

### DIFF
--- a/.github/workflows/gasp-prod-smoke-test.yml
+++ b/.github/workflows/gasp-prod-smoke-test.yml
@@ -127,14 +127,14 @@ jobs:
           dest: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ReportData ${{ matrix.command }}
           path: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: TestReport ${{ matrix.command }}

--- a/.github/workflows/microapps-ui-test.yml
+++ b/.github/workflows/microapps-ui-test.yml
@@ -159,14 +159,14 @@ jobs:
           dest: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ReportData
           path: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: TestReport

--- a/.github/workflows/ui-prod-smoke-test.yml
+++ b/.github/workflows/ui-prod-smoke-test.yml
@@ -125,14 +125,14 @@ jobs:
           dest: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ReportData ${{ matrix.command }}
           path: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: TestReport ${{ matrix.command }}

--- a/.github/workflows/ui-test.yml
+++ b/.github/workflows/ui-test.yml
@@ -155,14 +155,14 @@ jobs:
           dest: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ReportData ${{ matrix.command }}
           path: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: TestReport ${{ matrix.command }}

--- a/.github/workflows/upgradeEnvironment.yml
+++ b/.github/workflows/upgradeEnvironment.yml
@@ -168,14 +168,14 @@ jobs:
           dest: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ReportData
           path: reports.zip
 
       - name: Archive report files
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: TestReport


### PR DESCRIPTION
We are getting some errors like:
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/

bumping this artifact to v4 as suggested